### PR TITLE
correct reference to DATABASE_URL environment variable

### DIFF
--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -8,7 +8,7 @@ export default {
 };
 
 function createDatabaseUrl() {
-	if (process.env.DATBASE_URL) {
+	if (process.env.DATABASE_URL) {
 		return process.env.DATABASE_URL;
 	}
 	const host = process.env.DB_HOST ?? "localhost";


### PR DESCRIPTION
## Description

There is an incorrect reference to an environment variable `DATABASE_URL`, and this might be causing the deployed app on Heroku to not connect to the database there.