### PR TITLE
correct image file loading under webpack 5

### DIFF
--- a/client/webpack/common.config.js
+++ b/client/webpack/common.config.js
@@ -16,7 +16,7 @@ module.exports = {
 			},
 			{
 				test: /\.(png|svg|jpe?g|gif)$/,
-				loader: "file-loader",
+				type: "asset/resource",
 			},
 			{
 				test: /\.css$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"express": "^4.18.1",
 				"helmet": "^6.0.0",
 				"morgan": "^1.10.0",
-				"navigate": "^0.3.6",
 				"pg": "^8.8.0",
 				"redirect": "^0.2.0",
 				"winston": "^3.8.1"
@@ -39,7 +38,6 @@
 				"eslint-plugin-prettier": "^4.2.1",
 				"eslint-plugin-react": "^7.31.1",
 				"eslint-plugin-react-hooks": "^4.6.0",
-				"file-loader": "^6.2.0",
 				"html-webpack-plugin": "^5.5.0",
 				"html-webpack-tags-plugin": "^3.0.2",
 				"jest-environment-jsdom": "^29.0.1",
@@ -5373,44 +5371,6 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"node_modules/file-loader": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
-			"integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-			"dev": true,
-			"dependencies": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
-			}
-		},
-		"node_modules/file-loader/node_modules/schema-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
-		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -7377,14 +7337,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
-		},
-		"node_modules/navigate": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/navigate/-/navigate-0.3.6.tgz",
-			"integrity": "sha512-2m4e51H3BFTRs3xEWTZDRw+0QByI6245oDGQyubaEJNI0R/Htf6Oh4Hw6VH5dsWYD82iAwpnanXDmECKEuXPGQ==",
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/nconf": {
 			"version": "0.6.9",
@@ -14638,29 +14590,6 @@
 				"flat-cache": "^3.0.4"
 			}
 		},
-		"file-loader": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
-			"integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0"
-			},
-			"dependencies": {
-				"schema-utils": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.8",
-						"ajv": "^6.12.5",
-						"ajv-keywords": "^3.5.2"
-					}
-				}
-			}
-		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -16127,11 +16056,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
-		},
-		"navigate": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/navigate/-/navigate-0.3.6.tgz",
-			"integrity": "sha512-2m4e51H3BFTRs3xEWTZDRw+0QByI6245oDGQyubaEJNI0R/Htf6Oh4Hw6VH5dsWYD82iAwpnanXDmECKEuXPGQ=="
 		},
 		"nconf": {
 			"version": "0.6.9",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
 		"eslint-plugin-prettier": "^4.2.1",
 		"eslint-plugin-react": "^7.31.1",
 		"eslint-plugin-react-hooks": "^4.6.0",
-		"file-loader": "^6.2.0",
 		"html-webpack-plugin": "^5.5.0",
 		"html-webpack-tags-plugin": "^3.0.2",
 		"jest-environment-jsdom": "^29.0.1",


### PR DESCRIPTION
## Description

The webpack config for image file loading didn't work quite right as Webpack 5 is being used in the project. This updates the webpack config file for Webpack 5, and also removes the file-loader package as a dependency as this behaviour is now built into Webpack.