### PR TITLE
set nanoid to 3.X version so it can be used with CJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"express": "^4.18.1",
 				"helmet": "^6.0.0",
 				"morgan": "^1.10.0",
+				"nanoid": "^3.0.0",
 				"pg": "^8.8.0",
 				"react-icons": "^4.6.0",
 				"redirect": "^0.2.0",
@@ -7323,7 +7324,6 @@
 			"version": "3.3.4",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
 			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -16052,8 +16052,7 @@
 		"nanoid": {
 			"version": "3.3.4",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-			"dev": true
+			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 		"express": "^4.18.1",
 		"helmet": "^6.0.0",
 		"morgan": "^1.10.0",
+		"nanoid": "^3.0.0",
 		"pg": "^8.8.0",
 		"react-icons": "^4.6.0",
 		"redirect": "^0.2.0",


### PR DESCRIPTION
Starting in 4.0, nanoid removes commonJS support. We still use commonJS.

On dev machines we seem to have worked around by not npm installing nanoid - but on the server it's missing