### PR TITLE
add a donate and receive end to end cypress test

### DIFF
--- a/e2e/integration/add-donator.cy.js
+++ b/e2e/integration/add-donator.cy.js
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker/locale/en_GB"
 
 describe('add a donator', () => {
     it('allows a user to add a donator', () => {
-        cy.visit('http://localhost:3000/')
+        cy.visit('/')
         cy.contains('Donate').click()
         const donatorName = faker.name.fullName()
         cy.get('input[name=name]').type(donatorName)
@@ -13,7 +13,7 @@ describe('add a donator', () => {
         const deliveryOptions = ['PICKUP', 'SHIP']
         cy.get('select[name=deliveryOption]').select(deliveryOptions[Math.floor(Math.random() * deliveryOptions.length)])
         cy.get('form').submit()
-        cy.visit('http://localhost:3000/list-requests')
+        cy.visit('/list-requests')
         cy.contains('Donator List Table').click()
         cy.get('table').should('include.text', donatorName)
     })

--- a/e2e/integration/donate-and-receive.cy.js
+++ b/e2e/integration/donate-and-receive.cy.js
@@ -1,0 +1,32 @@
+import { faker } from "@faker-js/faker/locale/en_GB"
+
+describe('add a donator and a requester, and exchange', () => {
+    it('follows donate and receive path with ship option right to end', () => {
+        cy.visit('/')
+        cy.contains('I want to donate a laptop').click()
+        const donatorName = faker.name.fullName()
+        cy.get('input[name=name]').type(donatorName)
+        cy.get('input[name=address]').type(faker.address.streetAddress(true))
+        cy.get('input[name=numberOfLaptops]').type(String(Math.floor(Math.random() * 4) + 1))
+        cy.get('input[name=phoneNumber]').type(faker.phone.number())
+        cy.get('input[name=email]').type(faker.internet.email())
+        cy.get('select[name=deliveryOption]').select('SHIP')
+        cy.get('form').submit()
+        cy.contains('Back Home').click()
+        cy.contains('I need a laptop').click()
+        const firstName = faker.name.firstName();
+        cy.get('input[name=firstName]').type(firstName)
+        cy.get('input[name=lastName]').type(faker.name.lastName())
+        cy.get('input[name=email]').type(faker.internet.email())
+        cy.get('input[name=phoneNumber]').type(faker.phone.number())
+        cy.get('form').submit()
+        cy.get('p.primary-text').should('include.text', 'Good News!!!')
+        cy.get('h1').should('include.text', 'You have been assigned a laptop')
+        const recipientAddress = faker.address.streetAddress(true)
+        cy.get('input[name=addressField]').type(recipientAddress)
+        cy.contains('Yes please!').click()
+        cy.get('h1').should('include.text', `Please let us know when you have received your laptop at ${recipientAddress}`)
+        cy.contains('Thanks, I\'ve got it').click()
+        cy.get('h1').should('include.text', 'Sweet! You now have your laptop. Time to start working on your application to Code Your Future?')
+    })
+})


### PR DESCRIPTION
## Description

Add a Cypress test to run a full donation pledge plus request and pick up cycle.

The test cannot clear application state at its beginning so anyone running this may want to run `npm run recreate-db` to start from an empty state so that any donated laptop will be assigned to the user requesting a laptop.

Best run from the Cypress dashboard opened using `npx cypress open`.

![animation showing Cypress test running](https://user-images.githubusercontent.com/97280/204399379-4709bd11-b5e2-46f7-bd98-8d01818db9e0.gif)
